### PR TITLE
Fixes to allow use with S100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ build/
 *.gch
 *.xml
 __pycache__
-
+.vs/

--- a/libsuo/framing/golay_deframer.hpp
+++ b/libsuo/framing/golay_deframer.hpp
@@ -47,6 +47,9 @@ public:
 
 		/* Legacy mode for GomSpace's U482C radios */
 		bool legacy_mode;
+
+		/* Generate more output */
+		bool verbose;
 	};
 
 	explicit GolayDeframer(const Config& conf = Config());

--- a/libsuo/modem/demod_gmsk_cont.hpp
+++ b/libsuo/modem/demod_gmsk_cont.hpp
@@ -57,6 +57,9 @@ public:
 
 		float symsync_bandwidth0;
 		float symsync_bandwidth1;
+		float symsync_rate_tol;
+
+		bool verbose;
 	};
 
 	GMSKContinousDemodulator(const Config& conf = Config());
@@ -106,6 +109,8 @@ private:
 	/* Buffers */
 	Frame* frame;
 
+	/* for verbose output */
+	Timestamp last_print_time;
 };
 
 }; // namespace suo


### PR DESCRIPTION
demod_gmsk_cont: limit symsync rate to be close to the theoretical value, 
golay_deframer: fix frame length checking, improve printouts and make them optional